### PR TITLE
Fixes #13

### DIFF
--- a/src/joystick_list_widget.cpp
+++ b/src/joystick_list_widget.cpp
@@ -72,8 +72,6 @@ JoystickListWidget::JoystickListWidget()
   add_button(Gtk::Stock::PROPERTIES, 1);
   add_button(Gtk::Stock::CLOSE, 0);
 
-  signal_response().connect(sigc::mem_fun(this, &JoystickListWidget::on_response));
-
   // Set model
   device_list = Gtk::ListStore::create(DeviceListColumns::instance());
   treeview.set_model(device_list);


### PR DESCRIPTION
on_response() function for any Gtk::Dialog is the default handler for the response signal, connecting it again causes two invocations for on_response(), thus causing the bug.