### PR TITLE
Fixed visual representation of the right stick of xbox 360 controller

### DIFF
--- a/src/joystick_test_widget.cpp
+++ b/src/joystick_test_widget.cpp
@@ -164,14 +164,23 @@ JoystickTestWidget::JoystickTestWidget(Joystick& joystick_, bool simple_ui)
     stick_hbox.pack_start(left_trigger_widget, Gtk::PACK_EXPAND_PADDING);
     stick_hbox.pack_start(right_trigger_widget, Gtk::PACK_EXPAND_PADDING);
 
+    // Special case for the X-Box 360 pad, the mapping of the buttons seems to be different
+    // than normal(?). With the following code the widgets of the application will work correctly
+    if (joystick.get_name().compare("Microsoft X-Box 360 pad") == 0) {
+      axis_callbacks[2].connect(sigc::mem_fun(left_trigger_widget, &ThrottleWidget::set_pos));
+      axis_callbacks[3].connect(sigc::mem_fun(stick2_widget, &AxisWidget::set_x_axis));
+      axis_callbacks[4].connect(sigc::mem_fun(stick2_widget, &AxisWidget::set_y_axis));
+      axis_callbacks[5].connect(sigc::mem_fun(right_trigger_widget, &ThrottleWidget::set_pos));
+    } else {
+      axis_callbacks[2].connect(sigc::mem_fun(stick2_widget, &AxisWidget::set_x_axis));
+      axis_callbacks[3].connect(sigc::mem_fun(stick2_widget, &AxisWidget::set_y_axis));
+      axis_callbacks[4].connect(sigc::mem_fun(left_trigger_widget, &ThrottleWidget::set_pos));
+      axis_callbacks[5].connect(sigc::mem_fun(right_trigger_widget, &ThrottleWidget::set_pos));
+    }
     axis_callbacks[0].connect(sigc::mem_fun(stick1_widget, &AxisWidget::set_x_axis));
     axis_callbacks[1].connect(sigc::mem_fun(stick1_widget, &AxisWidget::set_y_axis));
-    axis_callbacks[2].connect(sigc::mem_fun(stick2_widget, &AxisWidget::set_x_axis));
-    axis_callbacks[3].connect(sigc::mem_fun(stick2_widget, &AxisWidget::set_y_axis));
     axis_callbacks[6].connect(sigc::mem_fun(stick3_widget, &AxisWidget::set_x_axis));
     axis_callbacks[7].connect(sigc::mem_fun(stick3_widget, &AxisWidget::set_y_axis));
-    axis_callbacks[4].connect(sigc::mem_fun(left_trigger_widget, &ThrottleWidget::set_pos));
-    axis_callbacks[5].connect(sigc::mem_fun(right_trigger_widget, &ThrottleWidget::set_pos));
     break;
 
 


### PR DESCRIPTION
I am using a X-Box 360 controller and noticed that the mapping of the the **Left Trigger** and the mappings of the **Right Thumbstick** were wrong.
The bugs are fixed in the code I submitted. It only works when you have a controller with the joystick.get_name() of "Microsoft X-Box 360 pad", because I didn't want to break compatibility with other joysticks that might have 8 axis (unfortunately I don't have such a controller).
