### PR TITLE
Bumping minimum cmake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(jstest-gtk VERSION 0.1.1)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
CMake v4.0 dropped support for versions older than 3.5: https://cmake.org/cmake/help/latest/release/4.0.html#id12

Version 3.5 was released in 2018, 6½ years ago: https://cmake.org/cmake/help/latest/release/4.0.html#id12

This commit has been ported from AUR: https://aur.archlinux.org/packages/jstest-gtk-git